### PR TITLE
fix: ignore missing option blocks

### DIFF
--- a/src/pcapng/blocks/opt_common.rs
+++ b/src/pcapng/blocks/opt_common.rs
@@ -59,7 +59,8 @@ pub(crate) trait PcapNgOption<'a> {
             options.push(opt);
         }
 
-        Err(PcapError::InvalidField("Invalid option"))
+        // Err(PcapError::InvalidField("Invalid option"))
+        Ok((slice, options))
     }
 
     /// Write the option to a writer
@@ -133,7 +134,8 @@ pub(crate) trait AsyncPcapNgOption<'a> {
             options.push(opt);
         }
 
-        Err(PcapError::InvalidField("Invalid option"))
+        // Err(PcapError::InvalidField("Invalid option"))
+        Ok((slice, options))
     }
 
     /// Write the option to a writer


### PR DESCRIPTION
If I use your lib through https://crates.io/crates/tzsp/0.1.0, it crashes with missing options (code == 0 is missing, so the slice becomes empty -> crashes) even if they can be safely ignored.